### PR TITLE
docs: add immutable releases badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # organization-readme-badge-generator
 
 [![GitHub release](https://img.shields.io/github/release/joshjohanning/organization-readme-badge-generator.svg?logo=github&labelColor=333)](https://github.com/joshjohanning/organization-readme-badge-generator/releases)
+[![Immutable releases](https://img.shields.io/badge/releases-immutable-blue?labelColor=333)](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/immutable-releases)
 [![GitHub marketplace](https://img.shields.io/badge/marketplace-github--organization--readme--badge--generator-blue?logo=github&labelColor=333)](https://github.com/marketplace/actions/github-organization-readme-badge-generator)
 [![CI](https://github.com/joshjohanning/organization-readme-badge-generator/actions/workflows/ci.yml/badge.svg)](https://github.com/joshjohanning/organization-readme-badge-generator/actions/workflows/ci.yml)
 [![Publish GitHub Action](https://github.com/joshjohanning/organization-readme-badge-generator/actions/workflows/publish.yml/badge.svg)](https://github.com/joshjohanning/organization-readme-badge-generator/actions/workflows/publish.yml)


### PR DESCRIPTION
Add the [immutable releases](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/immutable-releases) badge to the README, consistent with the other JS actions in the suite.
